### PR TITLE
Update for env_setup firestore creation to set expected project

### DIFF
--- a/env_setup.py
+++ b/env_setup.py
@@ -460,7 +460,8 @@ def create_firestore_db(firestore_region=FIRESTORE_REGION,firestore_database="op
         create_db_cmd = [
             "gcloud", "firestore", "databases", "create", 
             "--database", firestore_database,
-            "--location", firestore_region
+            "--location", firestore_region,
+            "--project", PROJECT_ID
         ]
         subprocess.run(create_db_cmd, check=True)  # Raise exception on failure
 


### PR DESCRIPTION
Added `--project` flag so firestore is created in correct project that is expected and passed by.

