### PR TITLE
fix: missing positional args in 1_Setup notebook

### DIFF
--- a/notebooks/1_Setup_OpenDataQnA.ipynb
+++ b/notebooks/1_Setup_OpenDataQnA.ipynb
@@ -298,8 +298,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Fill out the parameters and configuration settings below.\n",
     "These are the parameters for setting configurations for the vector store tables to be created.\n",
@@ -366,7 +366,7 @@
    "source": [
     "from scripts import save_config\n",
     "\n",
-    "save_config(embedding_model, description_model, vector_store, logging, kgq_examples, use_column_samples, PROJECT_ID,\n",
+    "save_config(embedding_model, description_model, vector_store, logging, kgq_examples, use_session_history, use_column_samples, PROJECT_ID,\n",
     "            pg_region, pg_instance, pg_database, pg_user, pg_password, \n",
     "            bq_dataset_region, bq_opendataqna_dataset_name, bq_log_table_name,firestore_region)"
    ]


### PR DESCRIPTION
Resolves #60 

Added `use_session_history` to `save_config()` in [1_Setup_OpenDataQnA.ipynb](https://github.com/GoogleCloudPlatform/Open_Data_QnA/blob/main/notebooks/1_Setup_OpenDataQnA.ipynb) Notebook.
