### PR TITLE
Fix bugs backend apis

### DIFF
--- a/backend-apis/main.py
+++ b/backend-apis/main.py
@@ -349,8 +349,11 @@ async def getNaturalResponse():
    
    user_question = envelope.get('user_question')
    user_grouping = envelope.get('user_grouping')
+   session_id = envelope.get('session_id')
+   user_id = envelope.get('user_id')
    
-   generated_sql,session_id,invalid_response = await generate_sql(user_question,
+   generated_sql,session_id,invalid_response = await generate_sql(session_id,
+                user_question,
                 user_grouping,  
                 RUN_DEBUGGER,
                 DEBUGGING_ROUNDS, 
@@ -364,19 +367,21 @@ async def getNaturalResponse():
                 table_similarity_threshold,
                 column_similarity_threshold,
                 example_similarity_threshold,
-                num_sql_matches)
+                num_sql_matches,
+                user_id=user_id)
    
    if not invalid_response:
 
         result_df,invalid_response=get_results(user_grouping,generated_sql)
         
         if not invalid_response:
-            result,invalid_response=get_response(user_question,result_df.to_json(orient='records'))
+            result,invalid_response=get_response(session_id,user_question,result_df.to_json(orient='records'))
 
             if not invalid_response:
                 responseDict = { 
                             "ResponseCode" : 200, 
                             "summary_response" : result,
+                            "SessionID" : session_id,
                             "Error":""
                             } 
 
@@ -413,8 +418,11 @@ async def getResultsResponse():
    
    user_question = envelope.get('user_question')
    user_database = envelope.get('user_database')
+   session_id = envelope.get('session_id')
+   user_id = envelope.get('user_id')
    
-   generated_sql,invalid_response = await generate_sql(user_question,
+   generated_sql,session_id,invalid_response = await generate_sql(session_id,
+                user_question,
                 user_database,  
                 RUN_DEBUGGER,
                 DEBUGGING_ROUNDS, 
@@ -428,7 +436,8 @@ async def getResultsResponse():
                 table_similarity_threshold,
                 column_similarity_threshold,
                 example_similarity_threshold,
-                num_sql_matches)
+                num_sql_matches,
+                user_id=user_id)
    
    if not invalid_response:
 

--- a/notebooks/1_Setup_OpenDataQnA.ipynb
+++ b/notebooks/1_Setup_OpenDataQnA.ipynb
@@ -298,8 +298,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Fill out the parameters and configuration settings below.\n",
     "These are the parameters for setting configurations for the vector store tables to be created.\n",
@@ -366,7 +366,7 @@
    "source": [
     "from scripts import save_config\n",
     "\n",
-    "save_config(embedding_model, description_model, vector_store, logging, kgq_examples, use_column_samples, PROJECT_ID,\n",
+    "save_config(embedding_model, description_model, vector_store, logging, kgq_examples, use_session_history, use_column_samples, PROJECT_ID,\n",
     "            pg_region, pg_instance, pg_database, pg_user, pg_password, \n",
     "            bq_dataset_region, bq_opendataqna_dataset_name, bq_log_table_name,firestore_region)"
    ]


### PR DESCRIPTION
Resolves #64,

Changelog:
1. Added get session_id and user_id in `getNaturalResponse()` since they are required to be passed to `generate_sql`. If they are not received in the payload, they become none and default values are applied by `generate_sql`.
2. Pass session_id to `get_response()` as it is a required argument for that function. It is being received as response of generate_sql but not passed in to get_response().
3. Added session_id in the success response payload for `/natural_response` route.
4. Added session_id in tuple unpacking for `/get_results` since generate_sql() returns three values, but only two are expected.
5. Added session_id and user_id similar to 1st change in `/get_results`.

Edit:
Includes changes part of #63 as well